### PR TITLE
Add https-portal

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,3 +33,8 @@ services:
 volumes:
   images_tmp:
     driver: local
+
+https-portal:
+  environment:
+    STAGE: local
+    DOMAINS: 'http://www.shellgei-web.net'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,6 @@ services:
       - /tmp/nginx_log:/var/log/nginx  # Output log to host
     links:
       - webapp
-    ports:
-      - "80:80"
     environment:
       TZ: "Asia/Tokyo"
     command: nginx -c /etc/nginx/nginx.conf
@@ -30,11 +28,20 @@ services:
     build: ./executer
     command: echo "shellgei executer already initialized"
 
+  https-portal:
+    image: steveltn/https-portal:1
+    ports:
+      - "80:80"
+      - "443:443"
+    links:
+      - nginx
+    environment:
+      STAGE: local
+      #STAGE: production
+      DOMAINS: 'localhost -> http://nginx:80'
+      #DOMAINS: 'shellgei-web.net -> http://nginx:80'
+
 volumes:
   images_tmp:
     driver: local
 
-https-portal:
-  environment:
-    STAGE: local
-    DOMAINS: 'http://www.shellgei-web.net'


### PR DESCRIPTION
I added the following feature to the system.

- https://github.com/SteveLTN/https-portal

According to https://qiita.com/kuboon/items/f424b84c718619460c6f, it can make a web site be an https one. Please switch the following lines and test the site. 

```
      STAGE: local
      #STAGE: production
      DOMAINS: 'localhost -> http://nginx:80'
      #DOMAINS: 'shellgei-web.net -> http://nginx:80'
```

If there are some problems, don't hesitate to discard this request. 

Regards