### PR TITLE
add tweet button

### DIFF
--- a/webapp/static/js/editor.js
+++ b/webapp/static/js/editor.js
@@ -1,5 +1,5 @@
 // Copyright (c) 2019 Hiroki Takemura (kekeho)
-// 
+//
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
@@ -68,4 +68,10 @@ var run_button = document.getElementById('run_button');
 run_button.onclick = function() {
     let value = editor.getValue();
     post_shell_code(value);
+};
+
+var tweet_button = document.getElementById('tweet_button');
+tweet_button.onclick = function() {
+    let value = editor.getValue();
+    window.open("https://twitter.com/intent/tweet?text="+ encodeURI(editor.getValue()) + "&hashtags=" + encodeURI("シェル芸"))
 };

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -1,6 +1,6 @@
 <!--
  Copyright (c) 2019 Hiroki Takemura (kekeho)
- 
+
  This software is released under the MIT License.
  https://opensource.org/licenses/MIT
 -->
@@ -14,11 +14,14 @@
     <div class="row">
         <div class="col-md-6 editor-result-grid">  <!-- EDITOR -->
             <div class="row window-header">  <!-- header -->
-                <div class="col-10">
-                    <h3>Editor</h3>                    
+                <div class="col-8">
+                    <h3>Editor</h3>
                 </div>
                 <div class="col-2">
                     <p class="run_button" id="run_button">Run</p>
+                </div>
+                <div class="col-2">
+                    <p class="run_button" id="tweet_button">Tweet</p>
                 </div>
             </div>
             <div class="row">  <!-- editor -->


### PR DESCRIPTION
エディタの内容をツイートできるボタンを設置しました

### 既知の問題点

- テキスト内にハッシュ記号 `#` があるとそれ以降の文字列が消えてしまうみたいです。URLのクエリパラメタに `,` 区切りでハッシュタグを書けるのでそれを使えば良いといえば良いんですが、文字列のパースが面倒になるのと、ハッシュタグの位置が変わってしまってよろしくないです。これは https://twitter.com/intent/tweet からツイートする以外の方法を模索しないとダメそうです

### 将来の拡張

- SGWebで実験したツイートであることを明記するために、 `via` クエリパラメータを使っても良いかもしれません。（参照 https://developer.twitter.com/en/docs/twitter-for-websites/tweet-button/guides/web-intent.html 