### PR TITLE
catch an uncoughted exception JSONDecodeError

### DIFF
--- a/webapp/main.py
+++ b/webapp/main.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2019 Hiroki Takemura (kekeho)
-# 
+#
 # This software is released under the MIT License.
 # https://opensource.org/licenses/MIT
 
@@ -41,6 +41,9 @@ def post_code():
         stdout = resp['stdout']
         stderr = resp['stderr']
         images = resp['images']
+    except json.JSONDecodeError:
+        stdout, stderr, sysmsg = ('', '', '')
+        images = []
     except TimeoutExpired:
         stdout, stderr, sysmsg = ('', '', '[Error]: Timeout (over 10s)')
         images = []


### PR DESCRIPTION
空のシェル芸が実行されるとき、executor/entrypoint.py の `exit(0)` で虚無が返ってきて `json.loads` に失敗するケースがあったので例外を補足しました。 executor/entrypoint.py 側を変更するかこちらを変更するかは好みだと思ってます