### PR TITLE
Use standard module instead of magic number

### DIFF
--- a/executer/entrypoint.py
+++ b/executer/entrypoint.py
@@ -1,10 +1,11 @@
 import os
 import subprocess
+import sys
 import glob
 import base64
 import json
 
-with open(0) as f:
+with sys.stdin as f:
     code = f.read()
 
 if code == '':


### PR DESCRIPTION
アプリの動作にはなにも関係ないですが。。。

`with open(0) as f` でおそらく標準入力の読み込みをしているのだと思うのですが、`sys.stdin` があるのでそちらを使ったほうが explicit じゃないかという提案です。