### PR TITLE
コマンド実行結果の出力を見やすいデザインに修正

### DIFF
--- a/webapp/static/css/style.css
+++ b/webapp/static/css/style.css
@@ -63,6 +63,12 @@ pre {
 #image_row img {
     width: 100%;
 }
+#image_row .col {
+    min-width:50%;
+}
+#image_row .col:nth-child(n+2) {
+    max-width:50%;
+}
 
 #recents {
     list-style: none;

--- a/webapp/static/css/style.css
+++ b/webapp/static/css/style.css
@@ -53,7 +53,6 @@ body {
 
 pre {
     color: #eaeaea !important;
-    white-space: pre-wrap;
 }
 
 .footer-col {

--- a/webapp/static/js/editor.js
+++ b/webapp/static/js/editor.js
@@ -48,7 +48,7 @@ function images_insert(images_list) {
         img.setAttribute('src', 'data:image/*;base64,' + b64image);
 
         let col = document.createElement('div');
-        col.classList.add('col-6');
+        col.classList.add('col');
         col.appendChild(img);
 
         image_row.appendChild(col);

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -40,13 +40,19 @@
             <div class="row">  <!-- content -->
                 <div class="col-12">
                     <p>[stdout]</p>
-                    <pre id="exec-stdout"></pre>
+                    <div class="overflow-auto">
+                      <pre id="exec-stdout" class="d-inline-block"></pre>
+                    </div>
                     <p>[/images]</p>
                     <div class="row" id="image_row"></div>
                     <p>[stderr]</p>
-                    <pre id="exec-stderr"></pre>
+                    <div class="overflow-auto">
+                      <pre id="exec-stderr" class="d-inline-block"></pre>
+                    </div>
                     <p>[system message]</p>
-                    <pre id="system-message"></pre>
+                    <div class="overflow-auto">
+                      <pre id="system-message" class="d-inline-block"></pre>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
コマンド実行結果の出力を個人的にきれいだと思う形式で表示されるようにしてみました。
しかし、あえて意図してデザインされていたら申し訳ありません。
気に入っていただければ幸いです。

## 修正点
- [stdout]、[stderr]、[system message]の出力で改行があった場合でも正しく表示するよう
- [/images]の画像出力で1枚の場合はwidth:100%で2枚以上のときは50%で出力されるよう

---

以下詳細

## [stdout]、[stderr]、[system message]の出力の修正

現状では幅の長い文字列を表示する場合に、
改行コードを無視して改行が行われてしまいデザインが崩れている。
(Twitterでの幅と崩れを再現するように、あえて意図して崩しているのでしたらすみません)

![image](https://user-images.githubusercontent.com/7940709/67176062-8716ac00-f403-11e9-836a-a31d85f0cfa0.png)

きれいに表示し、枠からはみ出すとスクロールバーを出すように変更。

![image](https://user-images.githubusercontent.com/7940709/67177212-859bb280-f408-11e9-97e6-d9145d9c98da.png)


## 画像出力で1枚の場合はwidth:100%で2枚以上のときは50%で出力

現状の[/images]の画像出力はwidth:50%で出力するため、1枚のとき小さく表示されてしまう。
これは複数枚の出力がある際にTwitterの表示のように並べて出すデザインを意識していると考えられる。

しかし、大きな画像を表示したい際に小さくて見づらいことが多々あり気になった。

```bash
$ unko.shout|textimg -s
```

**現行:1枚表示**
![image](https://user-images.githubusercontent.com/7940709/67176678-04432080-f406-11e9-8d2f-5e05d89e0eb4.png)

```bash
$ seq 3|xargs -L1 -I@ bash -c 'unko.shout|textimg -o /images/@.png'
```

**現行:3枚表示**
![image](https://user-images.githubusercontent.com/7940709/67176657-f392aa80-f405-11e9-81af-a842faecd2f6.png)

### 変更後

これを1枚のときはwidth:100%でより見やすく。
2枚以上のときは現行と同じwidth:50%にして並べて表示するように変更

**変更後:1枚表示**
![image](https://user-images.githubusercontent.com/7940709/67176733-410f1780-f406-11e9-9efe-694cb6918ada.png)

**変更後:3枚表示**
![image](https://user-images.githubusercontent.com/7940709/67176803-86334980-f406-11e9-9d4c-761f97446c56.png)

## 新たに発見した課題
現行でも画像の出力は幅で揃えているため、
アスペクト比が異なる画像の出力が微妙な見た目になるのを発見した。
いつか解決したい。

```bash
$ seq 4|xargs -L1 -I@ bash -c 'muscular pose|textimg -o /images/@.png'
```

![image](https://user-images.githubusercontent.com/7940709/67176939-2d17e580-f407-11e9-8691-160c6f8b2ae6.png)
