### PR TITLE
Monaco Editorの部分のレスポンシブ対応

### DIFF
--- a/webapp/static/css/style.css
+++ b/webapp/static/css/style.css
@@ -30,12 +30,12 @@ body {
 }
 
 #editor {
-  height: 500px
+  height: 500px;
 }
 
 @media screen and (max-width:768px) {
   #editor {
-    height: 100px
+    height: 100px;
   }
 }
 

--- a/webapp/static/css/style.css
+++ b/webapp/static/css/style.css
@@ -29,6 +29,16 @@ body {
     padding-bottom: 2rem;
 }
 
+#editor {
+  height: 500px
+}
+
+@media screen and (max-width:768px) {
+  #editor {
+    height: 100px
+  }
+}
+
 .run_button {
     border: #eaeaea;
     border-width: 1px;

--- a/webapp/static/js/editor.js
+++ b/webapp/static/js/editor.js
@@ -18,6 +18,7 @@ require(['vs/editor/editor.main'], function() {
         language: 'shell',
         theme: 'vs-dark',
         minimap: { enabled: false },
+        automaticLayout : true,
         model: model
     });
 

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -26,7 +26,7 @@
             </div>
             <div class="row">  <!-- editor -->
                 <div class="col-12">
-                    <div id="editor" style="height: 500px;"></div>
+                    <div id="editor"></div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Monaco Editorの部分のスタイルについて変更を加えてみました。
 気に入っていただければ幸いです。

## 修正点
 - ブラウザのウィンドウサイズが変更されてもMonaco Editorの部分が固定サイズになっているのを可変に変更
 - スマホなどの幅768px以下([Medium devices](https://getbootstrap.com/docs/4.0/layout/overview/#responsive-breakpoints))のウィンドウサイズの場合に、Monaco Editorの高さ500pxでは操作しづらいため、幅に合わせ高さを100pxに変更するように変更

## 現行のデザイン

![Peek 2019-10-21 23-14](https://user-images.githubusercontent.com/7940709/67214098-2070ad00-f45a-11e9-9096-31b53fe578d7.gif)

## 修正後のデザイン

![Peek 2019-10-21 23-16](https://user-images.githubusercontent.com/7940709/67214120-28c8e800-f45a-11e9-8f5f-cf20d0b6ff13.gif)
